### PR TITLE
Fix: add closing remarks to sudden death

### DIFF
--- a/server/helper/formTriviaBlock.js
+++ b/server/helper/formTriviaBlock.js
@@ -380,6 +380,10 @@ export const sendSuddenDeathWinner = (player) => {
     `${name} survives sudden death and takes the :crown:!`,
     '*What a champion!* :muscle:',
     '\n',
+    'I guess that\'s all for today\'s trivia',
+    'Hope everybody learned something today',
+    'I\'ll see you next time! :v:',
+    '\n',
   ]);
 };
 


### PR DESCRIPTION
## Summary
- Adds the standard closing remarks ("I guess that's all for today's trivia", "Hope everybody learned something today", "I'll see you next time!") to the sudden death winner message, matching the regular game ending flow.

## Test plan
- [x] 58 server tests passing
- [ ] Manual: Verify sudden death ending shows closing remarks