### PR TITLE
Fix: remove babel-minify and fix Redis boolean HSET

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,9 +9,6 @@
   ],
   "env": {
     "production": {
-      "presets": [
-        ["minify", { "builtIns": false }]
-      ]
     }
   }
 }

--- a/server/util/redisClient.js
+++ b/server/util/redisClient.js
@@ -47,8 +47,10 @@ class RedisClient {
       const hset = [key];
       Object.keys(object).forEach((k) => {
         hset.push(k);
-        if (typeof object[k] === 'string' || typeof object[k] === 'boolean') {
+        if (typeof object[k] === 'string') {
           hset.push(object[k]);
+        } else if (typeof object[k] === 'boolean') {
+          hset.push(String(object[k]));
         } else {
           const buffer = Buffer.from(JSON.stringify(object[k]));
           hset.push(buffer);


### PR DESCRIPTION
## Summary
- **Root cause:** `babel-preset-minify` was converting arrow functions to regular functions without preserving lexical `this`, causing `setState()` to crash silently. This meant the trivia game state was never persisted to Redis and the game couldn't progress past the reminder.
- **Secondary fix:** Redis HSET rejects raw JS `false` values — booleans are now converted to strings before writing.

## Test plan
- [x] 58 server tests passing
- [ ] Manual: Verify trivia starts after the 5-minute countdown