### PR TITLE
Fix: use HMSET for Redis 3.2 compat

### DIFF
--- a/server/util/redisClient.js
+++ b/server/util/redisClient.js
@@ -56,7 +56,7 @@ class RedisClient {
           hset.push(buffer);
         }
       });
-      this.client.hset(hset);
+      this.client.hmset(hset);
       resolve(true);
     });
   }


### PR DESCRIPTION
Redis 3.2 on EC2 only supports single-field HSET. Switch to HMSET for multi-field writes.